### PR TITLE
refactor: move + operator from TrackedResult to TextRange

### DIFF
--- a/src/EasyParsing/TextRange.cs
+++ b/src/EasyParsing/TextRange.cs
@@ -5,4 +5,13 @@ namespace EasyParsing;
 /// </summary>
 /// <param name="Start">Start position of the text range.</param>
 /// <param name="End">End position of the text range.</param>
-public record TextRange(TextPosition Start, TextPosition End);
+public record TextRange(TextPosition Start, TextPosition End)
+{
+    /// <summary>
+    /// Combines two tracked results, taking the start of A and the end of B.
+    /// </summary>
+    public static TextRange operator +(TextRange a, TextRange b)
+    {
+        return a with { End = b.End };
+    }
+}

--- a/src/EasyParsing/TrackedResult.cs
+++ b/src/EasyParsing/TrackedResult.cs
@@ -6,13 +6,4 @@ namespace EasyParsing;
 /// <param name="Value"></param>
 /// <param name="Range"></param>
 /// <typeparam name="T"></typeparam>
-public record TrackedResult<T>(T Value, TextRange Range)
-{
-    /// <summary>
-    /// Combines two tracked results, taking the start of A and the end of B.
-    /// </summary>
-    public static TrackedResult<T> operator +(TrackedResult<T> a, TrackedResult<T> b)
-    {
-        return a with { Range = new TextRange(a.Range.Start, b.Range.End) };
-    }
-}
+public record TrackedResult<T>(T Value, TextRange Range);


### PR DESCRIPTION
Shift the `+` operator implementation from `TrackedResult` to `TextRange` for improved logical separation and streamlined responsibilities.